### PR TITLE
Fix scrollbar issues and make table rows colorable

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -33,6 +33,7 @@
     "dependencies": {
         "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
         "andrewMacmurray/elm-delay": "3.0.0 <= v < 4.0.0",
+        "avh4/elm-color": "1.0.0 <= v < 2.0.0",
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",

--- a/src/Examples.elm
+++ b/src/Examples.elm
@@ -10,7 +10,6 @@ import Browser
 import Browser.Dom
 import Browser.Events
 import Delay exposing (TimeUnit(..))
-import Dict
 import Element exposing (Element, alignTop, below, fill, html, inFront, onLeft, padding, px, shrink, spacing)
 import Element.Border
 import Element.Events
@@ -1083,6 +1082,17 @@ mainContent model =
                         , width fill
                         , infinite { loadingBottom = model.loadingBottom, loadingTop = model.loadingTop, loadExtraItems = \direction -> Just { loadCount = List.length persons, excessCount = 0, loadMsg = LoadPeople direction } }
                         , id "infinite-data-table"
+                        , DataTable.rowColor
+                            (\p ->
+                                if p.age > 30 then
+                                    Just (Element.rgb255 255 204 203)
+
+                                else if p.age == 29 then
+                                    Just (Element.rgb255 144 238 144)
+
+                                else
+                                    Nothing
+                            )
                         ]
                         { columns =
                             [ DataTable.column (Element.text "First name") (fill |> Element.minimum 100) (\_ person -> Element.text person.firstName)

--- a/src/Hatchinq/Attribute.elm
+++ b/src/Hatchinq/Attribute.elm
@@ -1,6 +1,7 @@
 module Hatchinq.Attribute exposing
     ( Attribute
     , custom, height, id, none, toElement, toInternalConfig, toId, toWidth, width, withAttributes
+    , toHeight
     )
 
 {-|
@@ -103,6 +104,25 @@ toWidth source =
                     (\i ->
                         case i of
                             Width l ->
+                                Just <| l
+
+                            _ ->
+                                Nothing
+                    )
+            )
+        )
+
+
+{-| -}
+toHeight : List (Attribute v) -> Maybe Length
+toHeight source =
+    List.head
+        (List.reverse
+            (source
+                |> List.filterMap
+                    (\i ->
+                        case i of
+                            Height l ->
                                 Just <| l
 
                             _ ->

--- a/src/Hatchinq/TextField.elm
+++ b/src/Hatchinq/TextField.elm
@@ -39,7 +39,6 @@ type State id
 type alias InternalConfig =
     { multiline : Bool
     , password : Bool
-    , scrollbarY : Bool
     }
 
 
@@ -64,12 +63,6 @@ multiline =
 password : Attribute InternalConfig
 password =
     custom (\v -> { v | password = True })
-
-
-{-| -}
-scrollbarY : Attribute InternalConfig
-scrollbarY =
-    custom (\v -> { v | scrollbarY = True })
 
 
 {-| -}
@@ -133,7 +126,6 @@ view { theme, lift } attributes { id, label, value, state, onChange } =
         defaultInternalConfig =
             { multiline = False
             , password = False
-            , scrollbarY = False
             }
 
         internalConfig =

--- a/src/Hatchinq/Theme.elm
+++ b/src/Hatchinq/Theme.elm
@@ -1,6 +1,6 @@
 module Hatchinq.Theme exposing
     ( ColorTheme, ColorType, FontTheme, Theme
-    , arrowTransition, black, default, dense, font, icon, stylesheet, textWithEllipsis, transition, transparent, white, withColors
+    , arrowTransition, black, default, dense, font, icon, lightenOrDarken, stylesheet, textWithEllipsis, transition, transparent, white, withColors
     )
 
 {-|
@@ -9,10 +9,11 @@ module Hatchinq.Theme exposing
 # Exposed
 
 @docs ColorTheme, ColorType, FontTheme, Theme
-@docs arrowTransition, black, default, dense, font, icon, stylesheet, textWithEllipsis, transition, transparent, white, withColors
+@docs arrowTransition, black, default, dense, font, icon, lightenOrDarken, stylesheet, textWithEllipsis, transition, transparent, white, withColors
 
 -}
 
+import Color
 import Element exposing (Attribute, Color, Element, Length, el, fill, height, html, htmlAttribute, paddingXY, width)
 import Element.Font exposing (Font)
 import Hatchinq.Color as QColor exposing (alpha, blue, green, isBrighter, red, rgba, toElement, withAlpha)
@@ -745,5 +746,25 @@ textWithEllipsis text =
         , htmlAttribute <| Attr.style "display" "inline-block"
         , htmlAttribute <| Attr.style "overflow" "hidden"
         , htmlAttribute <| Attr.style "text-overflow" "ellipsis"
+        , htmlAttribute <| Attr.title text
         ]
         (html <| Html.text text)
+
+
+{-| -}
+lightenOrDarken : Element.Color -> Float -> Element.Color
+lightenOrDarken color amount =
+    let
+        rgb =
+            Element.toRgb color
+
+        hsl =
+            Color.toHsla <| Color.fromRgba { red = rgb.red, green = rgb.green, blue = rgb.blue, alpha = rgb.alpha }
+
+        newHsl =
+            { hsl | lightness = hsl.lightness + amount }
+
+        newColor =
+            Color.toRgba <| Color.fromHsla newHsl
+    in
+    Element.fromRgb { red = newColor.red, green = newColor.green, blue = newColor.blue, alpha = newColor.alpha }


### PR DESCRIPTION
The changes:
- Scrollbars will appear when using a fixed height for a multiline textfield
- Words without spaces are linebroken when they are longer than the width of the textfield
- Rows for a data table can be colored
- The amount of additional lightness can be provided when mouse is over a colored row in a data table (default is -0.05)
